### PR TITLE
Fix for utc_timestamp command

### DIFF
--- a/lib/unix.json
+++ b/lib/unix.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "utc_timestamp",
-      "kind": "COMMAND",
-      "source": "date --utc +%FT%H:%M:%S.%NZ",
+      "kind": "INLINE",
+      "source": "2020-09-25T08:18:04.996061145Z",
       "stdin": false
     },
     {

--- a/lib/unix.json
+++ b/lib/unix.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "utc_timestamp",
-      "kind": "INLINE",
-      "source": "2020-09-25T08:18:04.996061145Z",
+      "kind": "COMMAND",
+      "source": "date -u +%FT%H:%M:%S.%sZ",
       "stdin": false
     },
     {


### PR DESCRIPTION
closes #10 

Fixing utc_timestamp command to work on both Unix and Mac!